### PR TITLE
Fixed populate for cached request.

### DIFF
--- a/controllers/functions/createSocket.js
+++ b/controllers/functions/createSocket.js
@@ -239,9 +239,9 @@ module.exports = (socket, route, object, user, functions, options) => {
                   var options = clearCache ? {user,type:index,query,secondary,clearCache} : {user,type:index,query,secondary};
          
                   modelFunction[name][index](options, async (err, data) => {
-         
+                    console.log('DIZ DATE', data[0].groups)
                   var sendData = err ? err : data;
-                  sendData = await message.sockets(sendData);
+                  console.log('DIZ DATE', sendData[0].groups)
                   socket.emit(route, sendData);
                 });
               } else {

--- a/templates/customSocket.js
+++ b/templates/customSocket.js
@@ -70,7 +70,6 @@ socket.on('login', function (data) {
 
   }
 });function userCreate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userCreate', 
           {data:data}
@@ -78,13 +77,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userCreate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRead(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRead', 
           {data:data}
@@ -92,13 +95,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRead', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRemove(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRemove', 
           {data:data}
@@ -106,13 +113,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRemove', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userUpdate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userUpdate', 
           {data:data}
@@ -120,7 +131,12 @@ socket.on('login', function (data) {
       
         };
        socket.on('userUpdate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 

--- a/webServer/controllers/User/read.js
+++ b/webServer/controllers/User/read.js
@@ -1,6 +1,9 @@
 const User = require("../../models/User");
 
 var populate = '';
+
+
+
 Object.keys(User.schema.obj).forEach(function (key) {
   var val = User.schema.obj[key];
 
@@ -50,8 +53,9 @@ let read = {
 
     remove$(options.query);
 
-    const mongoose = await User.find(options.query, options.secondary).populate(typeof (noPopulate) !== "undefined" ? noPopulate : populate).cache(options.clearCache, options.clientID || options.query || options.user._id);
+    const mongoose = await User.find(options.query, options.secondary).cache(options.clearCache, options.clientID || options.query || options.user._id).populate(typeof (noPopulate) !== "undefined" ? noPopulate : populate);
 
+    console.log(mongoose, ' I CRY');
     sendCallBack(mongoose, done);
 
   },

--- a/webServer/public/js/customSocket.js
+++ b/webServer/public/js/customSocket.js
@@ -70,7 +70,6 @@ socket.on('login', function (data) {
 
   }
 });function userCreate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userCreate', 
           {data:data}
@@ -78,13 +77,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userCreate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRead(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRead', 
           {data:data}
@@ -92,13 +95,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRead', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRemove(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRemove', 
           {data:data}
@@ -106,13 +113,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRemove', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userUpdate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userUpdate', 
           {data:data}
@@ -120,7 +131,12 @@ socket.on('login', function (data) {
       
         };
        socket.on('userUpdate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 

--- a/webServer/securePublic/js/customSocket.js
+++ b/webServer/securePublic/js/customSocket.js
@@ -70,7 +70,6 @@ socket.on('login', function (data) {
 
   }
 });function userCreate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userCreate', 
           {data:data}
@@ -78,13 +77,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userCreate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRead(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRead', 
           {data:data}
@@ -92,13 +95,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRead', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userRemove(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userRemove', 
           {data:data}
@@ -106,13 +113,17 @@ socket.on('login', function (data) {
       
         };
        socket.on('userRemove', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
         })
        function userUpdate(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('userUpdate', 
           {data:data}
@@ -120,7 +131,12 @@ socket.on('login', function (data) {
       
         };
        socket.on('userUpdate', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 

--- a/webServer/services/redis.js
+++ b/webServer/services/redis.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-  config = require('../../config/config'),
+config = require('../../config/config'),
   redis = require('redis'),
   util = require('util'),
   client = redis.createClient(config.redis),
@@ -16,7 +16,11 @@ client.hset = util.promisify(client.hset);
 // });
 
 
+async function mongoosePopulate(populate, cache, model) {
 
+
+  return model;
+}
 
 
 mongoose.Query.prototype.cache = function (cache, id) {
@@ -32,59 +36,67 @@ mongoose.Query.prototype.cache = function (cache, id) {
 
 mongoose.Query.prototype.exec = async function () {
 
+
+
+
+
+
+
+
+
   if (!this.useCache) {
     return exec.apply(this, arguments)
   }
-
 
   const key = JSON.stringify(Object.assign({}, this.getQuery(), {
     collection: this.mongooseCollection.name
   }));
 
-
   // see if we have a vlaue for 'key' in redis.
-
 
   const cacheValue = await client.hget(JSON.stringify(this.clientID).replace(/"/g, ''), key);
 
-  // If we do, return that.
+  if (this.schema && this.schema.obj) {
+    var populate = '';
+    var model = this;
+    console.log('KEYS', Object.keys(this.schema.obj))
+    Object.keys(this.schema.obj).forEach(function (key) {
+      console.log('KEY');
+      var val = model.schema.obj[key];
 
+      if (typeof val === 'object' && val[0] && val[0].ref) {
+
+        populate += ` ${val[0].ref.toLowerCase()}`
+
+      }
+    });
+
+  }
+
+  // If we do, return that.
 
   if (cacheValue && JSON.parse(cacheValue).length > 0) {
 
     // console.log(crons[this.clientID + key]);
     var cron = crons[this.clientID + key];
 
-
-
-
-
     if (cron) {
       var time = moment(moment(cron.cronTime.source).format()).unix() * 1000;
       if (time > Date.now()) {
         var compare = Date.now() + 30000;
 
-        //  console.log(time)
-
-        //     crons[this.clientID + key].cronTime.source = moment(compare).parseZone();
         const CronTime = require('cron').CronTime;
         var time = new CronTime(new Date(compare));
-        //  crons[this.clientID + key].setTime(CronJob.time(new Date(compare)));
 
         crons[this.clientID + key].setTime(time);
         crons[this.clientID + key].start();
-        //   console.log( crons[this.clientID + key].cronTime.source );
+
       } else {
         crons[this.clientID + key].stop();
         delete crons[this.clientID + key];
       }
       const doc = JSON.parse(cacheValue);
-
-
-      return Array.isArray(doc)
-        ? doc.map(d => new this.model(d))
-        : new this.model(doc);
-
+      return doc;
     }
   }
 
@@ -131,6 +143,8 @@ mongoose.Query.prototype.exec = async function () {
 
 
   const result = await exec.apply(this, arguments);
+
+  console.log(JSON.stringify(result));
 
   client.hset(JSON.stringify(this.clientID).replace(/"/g, ''), key, JSON.stringify(result));
 

--- a/webServer/sockets/socket.io.js
+++ b/webServer/sockets/socket.io.js
@@ -64,7 +64,6 @@ require('./clientWrite')(() => {
             policyObject.push(obj[configName][route]);
 
             clientSocket(`function ${routeName}(data) {
-          console.log(data)
          t0 = performance.now();
         socket.emit('${routeName}', 
           {data:data}
@@ -72,7 +71,12 @@ require('./clientWrite')(() => {
       
         };
        socket.on('${routeName}', function (data) {
+         if(typeof(data) === 'string') {
+           data = JSON.parse(data);
+         }
          console.log(data)
+         console.log(data[0])
+         console.log(data[0].groups);
          var t1 = performance.now();
          console.log("Call to doSomething took " + (t1 - t0) + " milliseconds.")
 
@@ -147,7 +151,7 @@ module.exports = {
             if (policyObj.permissions && policyObj.permissions !== 0) {
               options.permissions = policyObj.permissions;
             }
-            
+
             createSocket(socket, policyObj.name.toLowerCase() + capFirst(policyObj.route), policyObj, activeClients[socket.id].user, policies, options)
 
           });


### PR DESCRIPTION
Fixing populate request for cached request. Fix: just send cached string as object and don't bother creating new mongoose object based off map information. (They are the same regardless) This should also increase cache query speed.